### PR TITLE
Don't set dashboard background to be black, to avoid embedded pages looking odd.

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -1,15 +1,12 @@
 html {
-  background-color: black;
   height: 100%;
 }
 
 body {
-  background-color: inherit;
   height: 100%;
   overflow: hidden;
   font-size: 35px;
   font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
-  color: #EEE;
 }
 
 html,
@@ -49,6 +46,10 @@ iframe {
   padding-top: 0.6em;
   font-size: 4em;
   font-family: "Lucida Console", Monaco, monospace;
+}
+
+#info {
+  background-color: black;
 }
 
 #info p {


### PR DESCRIPTION
As the background-color of the viewer is set to black, when a dashboard includes a page with no background-color set (so the background of the embedded page is transparent) , it appears to be black.

An example is this page:

http://6music.sharpshooterlabs.com/

When viewed as part of a dashy dashboard, the page background here is black, making the page look weird.

![image](https://cloud.githubusercontent.com/assets/1454180/7318100/0a7362c4-ea80-11e4-8819-3dd8c7a1e4b7.png)

This pull request makes a small change to the stylesheet for the viewer to set the background to be transparent (whilst keeping the top info bar black), so the page appears as expected:

![image](https://cloud.githubusercontent.com/assets/1454180/7318120/33d0e1f0-ea80-11e4-9fab-6c1808756293.png)

This change does mean that an unconfigured dashboard now has a white background, like this:

![image](https://cloud.githubusercontent.com/assets/1454180/7318137/7b8037bc-ea80-11e4-8fd6-32a77a26c976.png)
